### PR TITLE
feat: Sort cat list alphabetically

### DIFF
--- a/core/data/src/main/java/com/freedom/data/paging/BreedPagingSource.kt
+++ b/core/data/src/main/java/com/freedom/data/paging/BreedPagingSource.kt
@@ -30,7 +30,7 @@ class BreedPagingSource(
 
         return when (result) {
             is NetworkResult.Success -> {
-                val items = result.data
+                val items = result.data.sortedBy { it.breedModels.first().name }
                 val prev = (page - 1).takeIf { it >= 0 }
                 val next = if (items.size < limit) null else page + 1
                 LoadResult.Page(data = items, prevKey = prev, nextKey = next)

--- a/core/data/src/test/java/com/freedom/data/BreedModelRepositoryImplTest.kt
+++ b/core/data/src/test/java/com/freedom/data/BreedModelRepositoryImplTest.kt
@@ -75,5 +75,25 @@ class BreedModelRepositoryImplTest {
         assertNull(refreshKey)
     }
 
+    @Test
+    fun `load returns sorted Page when networkDatasource succeeds`() = runTest {
+        val datasource = mockk<NetworkDatasource>()
+        val catA = TestData.fakeCatImageDto.copy(breeds = listOf(TestData.fakeBreedDto.copy(name = "A")))
+        val catZ = TestData.fakeCatImageDto.copy(breeds = listOf(TestData.fakeBreedDto.copy(name = "Z")))
+        coEvery { datasource.getCatBreed(page = 0, limit = 2) } returns listOf(catZ, catA)
+        val source = BreedPagingSource(networkDatasource = datasource, limit = 2)
+
+        val params = PagingSource.LoadParams.Refresh(key = 0, loadSize = 2, placeholdersEnabled = false)
+        val result = source.load(params)
+
+
+        assertTrue(result is PagingSource.LoadResult.Page)
+        val page = result as PagingSource.LoadResult.Page<Int, CatModel>
+
+        assertEquals(2, page.data.size)
+        assertEquals("A", page.data[0].breedModels[0].name)
+        assertEquals("Z", page.data[1].breedModels[0].name)
+    }
+
 
 }


### PR DESCRIPTION
The list of cat breeds is now sorted alphabetically by breed name. This is done in the `BreedPagingSource` by sorting the list of items before they are returned.

A unit test has been added to verify the sorting logic.