### PR TITLE
feat: Add search filter for cat breeds

### DIFF
--- a/core/data/src/main/java/com/freedom/data/BreedRepository.kt
+++ b/core/data/src/main/java/com/freedom/data/BreedRepository.kt
@@ -4,5 +4,5 @@ import com.freedom.model.CatModel
 import kotlinx.coroutines.flow.Flow
 
 interface BreedRepository {
-     fun getCatBreed(limit: Int = 10): Flow<PagingData<CatModel>>
+     fun getCatBreed(query: String, limit: Int = 10): Flow<PagingData<CatModel>>
 }

--- a/core/data/src/main/java/com/freedom/data/BreedRepositoryImpl.kt
+++ b/core/data/src/main/java/com/freedom/data/BreedRepositoryImpl.kt
@@ -6,19 +6,25 @@ import androidx.paging.PagingData
 import com.freedom.common.NetworkResult
 import com.freedom.data.mapper.toDomain
 import com.freedom.data.paging.BreedPagingSource
+import com.freedom.data.paging.SearchPagingSource
 import com.freedom.model.CatModel
 import com.freedom.network.NetworkDatasource
-import com.freedom.network.retrofit.safeNetworkCall
 import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
 
 class BreedRepositoryImpl @Inject constructor(
     private val networkDatasource: NetworkDatasource
-):BreedRepository{
-    override fun getCatBreed(limit: Int): Flow<PagingData<CatModel>> {
+) : BreedRepository {
+    override fun getCatBreed(query: String, limit: Int): Flow<PagingData<CatModel>> {
         return Pager(
             config = PagingConfig(pageSize = limit, enablePlaceholders = false),
-            pagingSourceFactory = { BreedPagingSource(networkDatasource = networkDatasource, limit = limit) }
+            pagingSourceFactory = {
+                if (query.isBlank()) {
+                    BreedPagingSource(networkDatasource = networkDatasource, limit = limit)
+                } else {
+                    SearchPagingSource(networkDatasource = networkDatasource, query = query)
+                }
+            }
         ).flow
     }
 }

--- a/core/data/src/main/java/com/freedom/data/paging/SearchPagingSource.kt
+++ b/core/data/src/main/java/com/freedom/data/paging/SearchPagingSource.kt
@@ -1,0 +1,40 @@
+package com.freedom.data.paging
+
+import androidx.paging.PagingSource
+import androidx.paging.PagingState
+import com.freedom.data.mapper.toDomain
+import com.freedom.model.CatModel
+import com.freedom.network.NetworkDatasource
+import com.freedom.network.model.CatApiResponse
+
+class SearchPagingSource(
+    private val networkDatasource: NetworkDatasource,
+    private val query: String,
+) : PagingSource<Int, CatModel>() {
+
+    override fun getRefreshKey(state: PagingState<Int, CatModel>): Int? = null
+
+    override suspend fun load(params: LoadParams<Int>): LoadResult<Int, CatModel> {
+        return try {
+            val breeds = networkDatasource.searchBreeds(query)
+            val catModels = breeds.mapNotNull { breed ->
+                breed.referenceImageId?.let { imageId ->
+                    CatApiResponse(
+                        id = imageId,
+                        url = "https://cdn2.thecatapi.com/images/$imageId.jpg",
+                        breeds = listOf(breed),
+                        width = 0,
+                        height = 0
+                    ).toDomain()
+                }
+            }
+            LoadResult.Page(
+                data = catModels,
+                prevKey = null,
+                nextKey = null
+            )
+        } catch (e: Exception) {
+            LoadResult.Error(e)
+        }
+    }
+}

--- a/core/data/src/test/java/com/freedom/data/BreedModelRepositoryImplTest.kt
+++ b/core/data/src/test/java/com/freedom/data/BreedModelRepositoryImplTest.kt
@@ -4,6 +4,7 @@ import androidx.paging.PagingConfig
 import androidx.paging.PagingSource
 import androidx.paging.PagingState
 import com.freedom.data.paging.BreedPagingSource
+import com.freedom.data.paging.SearchPagingSource
 import com.freedom.model.CatModel
 import com.freedom.network.NetworkDatasource
 import io.mockk.coEvery
@@ -17,7 +18,7 @@ import org.junit.Test
 import java.io.IOException
 
 class BreedModelRepositoryImplTest {
-    private val network:NetworkDatasource = mockk()
+    private val network: NetworkDatasource = mockk()
     private lateinit var repository: BreedRepositoryImpl
 
     @Before
@@ -62,8 +63,10 @@ class BreedModelRepositoryImplTest {
     @Test
     fun `getRefreshKey returns null when no page covers anchorPosition`() {
         val source = BreedPagingSource(mockk(), limit = 4)
-        val page1: PagingSource.LoadResult.Page<Int, CatModel> = PagingSource.LoadResult.Page(emptyList(), prevKey = null, nextKey = 1)
-        val page2: PagingSource.LoadResult.Page<Int, CatModel> = PagingSource.LoadResult.Page(emptyList(), prevKey = 0,    nextKey = 2)
+        val page1: PagingSource.LoadResult.Page<Int, CatModel> =
+            PagingSource.LoadResult.Page(emptyList(), prevKey = null, nextKey = 1)
+        val page2: PagingSource.LoadResult.Page<Int, CatModel> =
+            PagingSource.LoadResult.Page(emptyList(), prevKey = 0, nextKey = 2)
         val state = PagingState(
             pages = listOf(page1, page2),
             anchorPosition = 5,
@@ -93,6 +96,25 @@ class BreedModelRepositoryImplTest {
         assertEquals(2, page.data.size)
         assertEquals("A", page.data[0].breedModels[0].name)
         assertEquals("Z", page.data[1].breedModels[0].name)
+    }
+
+    @Test
+    fun `search returns Page when networkDatasource succeeds`() = runTest {
+        val datasource = mockk<NetworkDatasource>()
+        val query = "beng"
+        coEvery { datasource.searchBreeds(query) } returns listOf(TestData.fakeBreedDto)
+        val source = SearchPagingSource(networkDatasource = datasource, query = query)
+
+        val params = PagingSource.LoadParams.Refresh(key = 0, loadSize = 1, placeholdersEnabled = false)
+        val result = source.load(params)
+
+        assertTrue(result is PagingSource.LoadResult.Page)
+        val page = result as PagingSource.LoadResult.Page<Int, CatModel>
+
+        assertEquals(1, page.data.size)
+        val cat = page.data.first()
+        assertEquals("birm", cat.breedModels[0].id)
+        assertEquals("Birman", cat.breedModels[0].name)
     }
 
 

--- a/core/network/src/main/java/com/freedom/network/NetworkDatasource.kt
+++ b/core/network/src/main/java/com/freedom/network/NetworkDatasource.kt
@@ -1,7 +1,9 @@
 package com.freedom.network
 
+import com.freedom.network.model.BreedDto
 import com.freedom.network.model.CatApiResponse
 
 interface NetworkDatasource {
     suspend fun getCatBreed(page: Int, limit: Int): List<CatApiResponse>
+    suspend fun searchBreeds(query: String): List<BreedDto>
 }

--- a/core/network/src/main/java/com/freedom/network/retrofit/CatApiService.kt
+++ b/core/network/src/main/java/com/freedom/network/retrofit/CatApiService.kt
@@ -11,4 +11,7 @@ interface CatApiService {
         @Query("page") page: Int,
         @Query("has_breeds") hasBreeds: Int = 1,
     ): List<CatApiResponse>
+
+    @GET("v1/breeds/search")
+    suspend fun searchBreeds(@Query("q") query: String): List<BreedDto>
 }

--- a/core/network/src/main/java/com/freedom/network/retrofit/NetworkDataSourceImpl.kt
+++ b/core/network/src/main/java/com/freedom/network/retrofit/NetworkDataSourceImpl.kt
@@ -7,4 +7,5 @@ class NetworkDataSourceImpl @Inject constructor(
     private val catApiService: CatApiService
 ): NetworkDatasource {
     override suspend fun getCatBreed(page: Int, limit: Int) = catApiService.getCatsWithBreeds(page = page, limit = limit)
+    override suspend fun searchBreeds(query: String) = catApiService.searchBreeds(query = query)
 }

--- a/features/breed-list/src/main/java/com/freedom/breed_list/BreedListScreen.kt
+++ b/features/breed-list/src/main/java/com/freedom/breed_list/BreedListScreen.kt
@@ -4,15 +4,19 @@ package com.freedom.breed_list
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -29,51 +33,66 @@ fun BreedListScreen(
     onCardClicked: (CatModel) -> Unit
 ) {
     val breeds = viewModel.cats.collectAsLazyPagingItems()
+    val searchQuery by viewModel.searchQuery.collectAsState()
 
     Scaffold(containerColor = MaterialTheme.colorScheme.surface) { padding ->
-        LazyColumn(
+        Column(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(padding)
-                .padding(horizontal = 16.dp, vertical = 8.dp),
-            verticalArrangement = Arrangement.spacedBy(12.dp)
+                .padding(horizontal = 16.dp, vertical = 8.dp)
         ) {
-            items(breeds.itemCount) { index ->
-                breeds[index]?.let {
-                    BreedCard(
-                        catModel = it,
-                        onCardClick = onCardClicked
-                    )
-                }
-            }
-
-            when (breeds.loadState.append) {
-                is LoadState.Loading -> item {
-                    Box(
-                        modifier = Modifier.fillMaxWidth().padding(16.dp),
-                        contentAlignment = Alignment.Center
-                    ) {
-                        CircularProgressIndicator()
+            OutlinedTextField(
+                value = searchQuery,
+                onValueChange = viewModel::onSearchQueryChanged,
+                modifier = Modifier.fillMaxWidth(),
+                placeholder = { Text("Search for a breed") },
+                singleLine = true
+            )
+            LazyColumn(
+                verticalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                items(breeds.itemCount) { index ->
+                    breeds[index]?.let {
+                        BreedCard(
+                            catModel = it,
+                            onCardClick = onCardClicked
+                        )
                     }
                 }
 
-                is LoadState.Error -> item {
-                    Text(
-                        text = "Error loading more",
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .clickable { breeds.retry() }
-                            .padding(16.dp),
-                        color = Color.Red
-                    )
-                }
+                when (breeds.loadState.append) {
+                    is LoadState.Loading -> item {
+                        Box(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(16.dp),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            CircularProgressIndicator()
+                        }
+                    }
 
-                else -> item {
-                    Box(
-                        modifier = Modifier.fillMaxWidth().padding(16.dp),
-                        contentAlignment = Alignment.Center
-                    ) {
-                        CircularProgressIndicator()
+                    is LoadState.Error -> item {
+                        Text(
+                            text = "Error loading more",
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .clickable { breeds.retry() }
+                                .padding(16.dp),
+                            color = Color.Red
+                        )
+                    }
+
+                    else -> item {
+                        Box(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(16.dp),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            CircularProgressIndicator()
+                        }
                     }
                 }
             }

--- a/features/breed-list/src/main/java/com/freedom/breed_list/BreedListViewModel.kt
+++ b/features/breed-list/src/main/java/com/freedom/breed_list/BreedListViewModel.kt
@@ -5,13 +5,26 @@ import androidx.lifecycle.viewModelScope
 import androidx.paging.cachedIn
 import com.freedom.data.BreedRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.flatMapLatest
 import javax.inject.Inject
 
 @HiltViewModel
 class BreedListViewModel @Inject constructor(
-    repository: BreedRepository
-): ViewModel(){
-    val cats = repository.getCatBreed(limit = PAGE_SIZE).cachedIn(viewModelScope)
+    private val repository: BreedRepository
+) : ViewModel() {
+
+    private val _searchQuery = MutableStateFlow("")
+    val searchQuery = _searchQuery.asStateFlow()
+
+    val cats = searchQuery.flatMapLatest { query ->
+        repository.getCatBreed(query = query, limit = PAGE_SIZE)
+    }.cachedIn(viewModelScope)
+
+    fun onSearchQueryChanged(query: String) {
+        _searchQuery.value = query
+    }
 
     companion object {
         private const val PAGE_SIZE = 10


### PR DESCRIPTION
This change adds a search filter to the cat breed list screen. Users can now search for cat breeds by name.

The implementation includes:
- A new `SearchPagingSource` to handle search results from the `/v1/breeds/search` endpoint.
- Updates to the `BreedRepository` and `BreedListViewModel` to handle the search query.
- A `TextField` in the UI for search input.
- Unit tests for the new search functionality.